### PR TITLE
Add string parser

### DIFF
--- a/Utilities/CodeParser.cs
+++ b/Utilities/CodeParser.cs
@@ -11,8 +11,8 @@ namespace percentCool.Utilities
         static int c = 0;
         static string cStr = "";
         static char currentChar => cStr[c];
-        static char previousChar => (c-1 >= 0 ? cStr[c] : '\0');
-
+        static char previousChar => (c-1 >= 0 ? cStr[c-1] : '\0');
+        static char nextChar => (c + 1 < cStr.Length ? cStr[c + 1] : '\0');
 
         public static string[] ParseLineIntoTokens(string inp)
         {
@@ -47,7 +47,7 @@ namespace percentCool.Utilities
                     }
                     else
                     {
-                        temp += currentChar;
+                        temp += (currentChar == '\\' && nextChar == '"') ? "" : currentChar;
                     }
                 }
 

--- a/Utilities/CodeParser.cs
+++ b/Utilities/CodeParser.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace percentCool.Utilities
+{
+    internal class CodeParser
+    {
+        static int c = 0;
+        static string cStr = "";
+        static char currentChar => cStr[c];
+        static char previousChar => (c-1 >= 0 ? cStr[c] : '\0');
+
+
+        public static string[] ParseLineIntoTokens(string inp)
+        {
+            c = 0;
+            cStr = inp;
+
+            List<string> tokens = new List<string>();
+
+            bool isReadingString = false;
+            string temp = "";
+
+            while (c < cStr.Length)
+            {
+                if(previousChar != '\\' && currentChar == '"')
+                {
+                    if(isReadingString) {
+                        tokens.Add(temp);
+                        temp = "";
+                        isReadingString = false;
+                    }else
+                    {
+                        if(temp != string.Empty) tokens.Add(temp);
+                        temp = "";
+                        isReadingString = true;
+                    }
+                }else
+                {
+                    if (!isReadingString && currentChar == ' ')
+                    {
+                        tokens.Add(temp);
+                        temp = "";
+                    }
+                    else
+                    {
+                        temp += currentChar;
+                    }
+                }
+
+                c++;
+            }
+
+            if(isReadingString)
+            {
+                Program.Error("Unterminated string!");
+                return new string[0];
+            }
+
+            if(temp != string.Empty) tokens.Add(temp);
+
+            return tokens.ToArray();
+        }
+    }
+}

--- a/Utilities/Utils.cs
+++ b/Utilities/Utils.cs
@@ -32,12 +32,13 @@ namespace percentCool.Utilities
             sb.Append(text, p, text.Length - p);
             return sb.ToString();
         }
-        public static string GetString()
+        public static string GetString(string[] args, int arg = 0)
         {
             string returnValue;
             try
             {
-                returnValue = Parser.line[currentChar..];
+                //returnValue = Parser.line[currentChar..];
+                returnValue = args[arg];
             }
             catch
             {


### PR DESCRIPTION
This PR adds a proper string parsing method, so arguments will be split properly. Utils.GetString() now requires the arguments array and the argument index, and currently isn't backward compatible with the old style.

Not compatible:
`echo Hello World!` (will print Hello)
Works:
`echo "Hello World!"` (will print Hello World!)

A workaround to support it could probably be done, but we shouldn't make the code even more messy. As this is a quick fix, and percentcool isn't widely used yet, I think its acceptable.