### PR TITLE
Remove '!' in error message

### DIFF
--- a/Utilities/CodeParser.cs
+++ b/Utilities/CodeParser.cs
@@ -58,7 +58,7 @@ namespace percentCool.Utilities
 
             if(isReadingString)
             {
-                Program.Error("Unterminated string!");
+                Program.Error("Unterminated string");
                 return new string[0];
             }
 


### PR DESCRIPTION
This makes the error message fit within the other error messages